### PR TITLE
50% increase in time inneficiency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,16 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "1.42.1"
+        "@playwright/test": "1.43.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz",
-      "integrity": "sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.43.0.tgz",
+      "integrity": "sha512-Ebw0+MCqoYflop7wVKj711ccbNlrwTBCtjY5rlbiY9kHL2bCYxq+qltK6uPsVBGGAOb033H2VO0YobcQVxoW7Q==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.42.1"
+        "playwright": "1.43.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -42,12 +42,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
-      "integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.0.tgz",
+      "integrity": "sha512-SiOKHbVjTSf6wHuGCbqrEyzlm6qvXcv7mENP+OZon1I07brfZLGdfWV0l/efAzVx7TF3Z45ov1gPEkku9q25YQ==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.42.1"
+        "playwright-core": "1.43.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.42.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
-      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.0.tgz",
+      "integrity": "sha512-iWFjyBUH97+pUFiyTqSLd8cDMMOS0r2ZYz2qEsPjH8/bX++sbIJT35MSwKnp1r/OQBAqC5XO99xFbJ9XClhf4w==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"

--- a/package.json
+++ b/package.json
@@ -1,13 +1,15 @@
 {
   "name": "1510",
   "version": "1.0.0",
-  "description": "",
+  "description": "BUG#30296",
   "main": "index.js",
-  "scripts": {},
+  "scripts": {
+    "test": "playwright test"
+  },
   "keywords": [],
-  "author": "",
+  "author": "Fernando Garcia",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "1.42.1"
+    "@playwright/test": "1.43.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, devices } from '@playwright/test';
+import { defineConfig } from '@playwright/test';
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -8,27 +8,27 @@ export default defineConfig({
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
+  // forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  // retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  // workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: 'list',
   projects: [
     {
-      name: 'project1',
+      name: 'login project',
       testMatch: /project1/
     },
 
     {
-      name: 'project2',
-      dependencies: ['project1'],
+      name: 'e2e auth project',
+      dependencies: ['login project'],
       testMatch: /project2/
     },
 
     {
-      name: 'project3',
+      name: 'e2e non-auth project',
       testMatch: /project3/
     },
   ],

--- a/tests/project1.test.ts
+++ b/tests/project1.test.ts
@@ -1,8 +1,7 @@
 import { test } from '@playwright/test';
 
-test('test', async () => {
-
-  console.log('project 1 (slow) started')
-  await new Promise(r => setTimeout(r, 10_000));
-  console.log('project 1 (slow) finished')
+test('project1 (login test)', async () => {
+  console.log('project 1 (login test) started')
+  await new Promise(r => setTimeout(r, 2_000));
+  console.log('project 1 (login test) (2s) finished')
 });

--- a/tests/project2.test.ts
+++ b/tests/project2.test.ts
@@ -1,5 +1,7 @@
 import { test } from '@playwright/test';
 
-test('test', () => {
-  console.log('project 2')
+test('project2 (e2e auth)', async () => {
+  console.log('project 2 (e2e auth) started')
+  await new Promise(r => setTimeout(r, 5_000));
+  console.log('project 2 (e2e auth) (5s) finished')
 });

--- a/tests/project3.test.ts
+++ b/tests/project3.test.ts
@@ -1,5 +1,7 @@
 import { test } from '@playwright/test';
 
-test('test', () => {
-  console.log('project 3')
+test('project3 (e2e noAuth)', async () => {
+  console.log('project 3 (e2e noAuth) started')
+  await new Promise(r => setTimeout(r, 10_000));
+  console.log('project 3 (e2e noAuth) (10s) finished')
 });


### PR DESCRIPTION
more real-world scenario / code which we you run locally `npm test`

In this example we can see a 50% increase in time inefficiency

Project1: login test project (2s)
Project2: e2e-auth project (5s) > requires project1
Project3: e2e-nonAuth project (10s) > no dependencies

Real world scenario , it should take just 10s to run in total (project3 time)
But it takes 15s (project2+project3 times)

@mxschmitt 